### PR TITLE
DRU-152 : Adding missing use statement.

### DIFF
--- a/src/ForkManager.php
+++ b/src/ForkManager.php
@@ -3,6 +3,7 @@
 namespace Async;
 
 use Async\Event\ForkEvent;
+use Async\Exception\InactiveForkException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Psr\Log\LoggerInterface;
 


### PR DESCRIPTION
Error:
```Fatal error: Uncaught Error: Class 'Async\InactiveForkException' not found in /Users/omkar/Projects/drutiny-cs-adaptor/vendor/fiasco/async/src/ForkManager.php on line 98

Error: Class 'Async\InactiveForkException' not found in /Users/omkar/Projects/drutiny-cs-adaptor/vendor/fiasco/async/src/ForkManager.php on line 98
```